### PR TITLE
Pass error in goroutine channels

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,11 @@ import (
 	"time"
 )
 
+type chan_ret_t struct {
+	series *influxClient.Series
+	err    error
+}
+
 const APP_VERSION = "0.5.3"
 
 // Variables storing arguments flags
@@ -185,7 +190,7 @@ func main() {
 			prefixFlag += "."
 		}
 
-		ch := make(chan *influxClient.Series, len(collectList))
+		ch := make(chan chan_ret_t, len(collectList))
 
 		// Without daemon mode, do at least one lap
 		first := true
@@ -202,8 +207,10 @@ func main() {
 
 			for i := len(collectList); i > 0; i-- {
 				res := <-ch
-				if res != nil {
-					data = append(data, res)
+				if res.err != nil {
+					fmt.Fprintf(os.Stderr, "%s\n", res.err)
+				} else if res.series != nil {
+					data = append(data, res.series)
 				} else if !daemonFlag {
 					// Loop if we haven't all data:
 					// Since diffed data didn't respond the
@@ -341,9 +348,9 @@ func DiffFromLast(serie *influxClient.Series) *influxClient.Series {
  * Gathering functions
  */
 
-type GatherFunc func(string, chan *influxClient.Series) error
+type GatherFunc func(string, chan chan_ret_t)
 
-func cpu(prefix string, ch chan *influxClient.Series) error {
+func cpu(prefix string, ch chan chan_ret_t) {
 	serie := &influxClient.Series{
 		Name:    prefix + "cpu",
 		Columns: []string{"id", "user", "nice", "sys", "idle", "wait", "total"},
@@ -352,16 +359,15 @@ func cpu(prefix string, ch chan *influxClient.Series) error {
 
 	cpu := sigar.Cpu{}
 	if err := cpu.Get(); err != nil {
-		ch <- nil
-		return err
+		ch <- chan_ret_t{nil, err}
+		return
 	}
 	serie.Points = append(serie.Points, []interface{}{"cpu", cpu.User, cpu.Nice, cpu.Sys, cpu.Idle, cpu.Wait, cpu.Total()})
 
-	ch <- DiffFromLast(serie)
-	return nil
+	ch <- chan_ret_t{DiffFromLast(serie), nil}
 }
 
-func cpus(prefix string, ch chan *influxClient.Series) error {
+func cpus(prefix string, ch chan chan_ret_t) {
 	serie := &influxClient.Series{
 		Name:    prefix + "cpus",
 		Columns: []string{"id", "user", "nice", "sys", "idle", "wait", "total"},
@@ -374,11 +380,10 @@ func cpus(prefix string, ch chan *influxClient.Series) error {
 		serie.Points = append(serie.Points, []interface{}{fmt.Sprint("cpu", i), cpu.User, cpu.Nice, cpu.Sys, cpu.Idle, cpu.Wait, cpu.Total()})
 	}
 
-	ch <- DiffFromLast(serie)
-	return nil
+	ch <- chan_ret_t{DiffFromLast(serie), nil}
 }
 
-func mem(prefix string, ch chan *influxClient.Series) error {
+func mem(prefix string, ch chan chan_ret_t) {
 	serie := &influxClient.Series{
 		Name:    prefix + "mem",
 		Columns: []string{"free", "used", "actualfree", "actualused", "total"},
@@ -387,16 +392,14 @@ func mem(prefix string, ch chan *influxClient.Series) error {
 
 	mem := sigar.Mem{}
 	if err := mem.Get(); err != nil {
-		ch <- nil
-		return err
+		ch <- chan_ret_t{nil, err}
 	}
 	serie.Points = append(serie.Points, []interface{}{mem.Free, mem.Used, mem.ActualFree, mem.ActualUsed, mem.Total})
 
-	ch <- serie
-	return nil
+	ch <- chan_ret_t{serie, nil}
 }
 
-func swap(prefix string, ch chan *influxClient.Series) error {
+func swap(prefix string, ch chan chan_ret_t) {
 	serie := &influxClient.Series{
 		Name:    prefix + "swap",
 		Columns: []string{"free", "used", "total"},
@@ -405,16 +408,15 @@ func swap(prefix string, ch chan *influxClient.Series) error {
 
 	swap := sigar.Swap{}
 	if err := swap.Get(); err != nil {
-		ch <- nil
-		return err
+		ch <- chan_ret_t{nil, err}
+		return
 	}
 	serie.Points = append(serie.Points, []interface{}{swap.Free, swap.Used, swap.Total})
 
-	ch <- serie
-	return nil
+	ch <- chan_ret_t{serie, nil}
 }
 
-func uptime(prefix string, ch chan *influxClient.Series) error {
+func uptime(prefix string, ch chan chan_ret_t) {
 	serie := &influxClient.Series{
 		Name:    prefix + "uptime",
 		Columns: []string{"length"},
@@ -423,16 +425,15 @@ func uptime(prefix string, ch chan *influxClient.Series) error {
 
 	uptime := sigar.Uptime{}
 	if err := uptime.Get(); err != nil {
-		ch <- nil
-		return err
+		ch <- chan_ret_t{nil, err}
+		return
 	}
 	serie.Points = append(serie.Points, []interface{}{uptime.Length})
 
-	ch <- serie
-	return nil
+	ch <- chan_ret_t{serie, nil}
 }
 
-func load(prefix string, ch chan *influxClient.Series) error {
+func load(prefix string, ch chan chan_ret_t) {
 	serie := &influxClient.Series{
 		Name:    prefix + "load",
 		Columns: []string{"one", "five", "fifteen"},
@@ -441,20 +442,19 @@ func load(prefix string, ch chan *influxClient.Series) error {
 
 	load := sigar.LoadAverage{}
 	if err := load.Get(); err != nil {
-		ch <- nil
-		return err
+		ch <- chan_ret_t{nil, err}
+		return
 	}
 	serie.Points = append(serie.Points, []interface{}{load.One, load.Five, load.Fifteen})
 
-	ch <- serie
-	return nil
+	ch <- chan_ret_t{serie, nil}
 }
 
-func network(prefix string, ch chan *influxClient.Series) error {
+func network(prefix string, ch chan chan_ret_t) {
 	fi, err := os.Open("/proc/net/dev")
 	if err != nil {
-	        ch <- nil
-		return err
+		ch <- chan_ret_t{nil, err}
+		return
 	}
 	defer fi.Close()
 
@@ -483,8 +483,8 @@ func network(prefix string, ch chan *influxClient.Series) error {
 		line := scanner.Text()
 		tmp := strings.Split(line, ":")
 		if len(tmp) < 2 {
-			ch <- nil
-			return nil
+			ch <- chan_ret_t{nil, nil}
+			return
 		}
 
 		iface := strings.Trim(tmp[0], " ")
@@ -504,15 +504,14 @@ func network(prefix string, ch chan *influxClient.Series) error {
 		serie.Points = append(serie.Points, points)
 	}
 
-	ch <- DiffFromLast(serie)
-	return nil
+	ch <- chan_ret_t{DiffFromLast(serie), nil}
 }
 
-func disks(prefix string, ch chan *influxClient.Series) error {
+func disks(prefix string, ch chan chan_ret_t) {
 	fi, err := os.Open("/proc/diskstats")
 	if err != nil {
-	        ch <- nil
-		return err
+		ch <- chan_ret_t{nil, err}
+		return
 	}
 	defer fi.Close()
 
@@ -530,8 +529,8 @@ func disks(prefix string, ch chan *influxClient.Series) error {
 	for scanner.Scan() {
 		tmp := strings.Fields(scanner.Text())
 		if len(tmp) < 14 {
-			ch <- nil
-			return nil
+			ch <- chan_ret_t{nil, nil}
+			return
 		}
 
 		var points []interface{}
@@ -548,11 +547,10 @@ func disks(prefix string, ch chan *influxClient.Series) error {
 		serie.Points = append(serie.Points, points)
 	}
 
-	ch <- DiffFromLast(serie)
-	return nil
+	ch <- chan_ret_t{DiffFromLast(serie), nil}
 }
 
-func mounts(prefix string, ch chan *influxClient.Series) error {
+func mounts(prefix string, ch chan chan_ret_t) {
 	serie := &influxClient.Series{
 		Name:    prefix + "mounts",
 		Columns: []string{"mountpoint", "disk", "free", "total"},
@@ -561,8 +559,8 @@ func mounts(prefix string, ch chan *influxClient.Series) error {
 
 	fi, err := os.Open("/proc/mounts")
 	if err != nil {
-	        ch <- nil
-		return err
+		ch <- chan_ret_t{nil, err}
+		return
 	}
 	defer fi.Close()
 
@@ -579,8 +577,8 @@ func mounts(prefix string, ch chan *influxClient.Series) error {
 
 			err := syscall.Statfs(tmp[1], &fs)
 			if err != nil {
-				ch <- nil
-				return err
+				ch <- chan_ret_t{nil, err}
+				return
 			}
 
 			freeBytes := fs.Bfree * uint64(fs.Bsize)
@@ -590,6 +588,5 @@ func mounts(prefix string, ch chan *influxClient.Series) error {
 		}
 	}
 
-	ch <- serie
-	return nil
+	ch <- chan_ret_t{serie, nil}
 }


### PR DESCRIPTION
As solution for the issue #24.

Can someone (cc @BarthV) review this fix?

The first alternative I tried, was to get the error returned to avoid prototype modification:

```diff
@@ -195,14 +195,19 @@ func main() {

                        // Collect data
                        var data []*influxClient.Series
+                       var errors = make([]error, len(data))

-                       for _, cl := range collectList {
-                               go cl(prefixFlag, ch)
+                       for k, cl := range collectList {
+                               go func() {
+                                  errors[k] = cl(prefixFlag, ch)
+                               }()
                        }

                        for i := len(collectList); i > 0; i-- {
                                res := <-ch
-                               if res != nil {
+                               if errors[i-1] != nil {
+                                       fmt.Fprintf(os.Stderr, "%s\n", errors[i-1])
+                               } else if res != nil {
                                        data = append(data, res)
                                } else if !daemonFlag {
                                        // Loop if we haven't all data:
```

But it doesn't work as expected :-(

Finally, I think the submitted commit is a cleaner way to do.